### PR TITLE
Hotfix: Remove PostgreSQL for Replit compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ tower-http = { version = "0.5", features = ["cors", "trace", "compression-gzip"]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
-# Database
-sqlx = { version = "0.7", features = ["runtime-tokio", "postgres", "sqlite", "uuid", "chrono", "json"] }
+# Database (sqlite only for Replit compatibility - postgres requires libpq)
+sqlx = { version = "0.7", features = ["runtime-tokio", "sqlite", "uuid", "chrono", "json"] }
 
 # Error handling
 thiserror = "1.0"

--- a/crates/mtg-server/src/config.rs
+++ b/crates/mtg-server/src/config.rs
@@ -38,7 +38,7 @@ fn default_port() -> u16 {
 }
 
 fn default_database_url() -> String {
-    "postgres://localhost/mtg_ai_suite".to_string()
+    "sqlite:./data/mtg_ai_suite.db?mode=rwc".to_string()
 }
 
 fn default_llm_provider() -> String {

--- a/replit.nix
+++ b/replit.nix
@@ -7,9 +7,8 @@
     pkgs.clippy
     pkgs.rustfmt
 
-    # Database
+    # Database (sqlite only - no postgres for Replit compatibility)
     pkgs.sqlite
-    pkgs.postgresql
 
     # Build dependencies
     pkgs.openssl


### PR DESCRIPTION
Removes PostgreSQL dependencies to fix Replit publish error.

## Changes
- Remove `pkgs.postgresql` from `replit.nix`
- Remove `postgres` feature from sqlx in `Cargo.toml`
- Change default database URL to SQLite

## Issue
Replit was failing with: 'Failed to fetch PostgreSQL major version for development database'

This is a minimal hotfix to unblock Replit publishing.